### PR TITLE
Borrow algorithms in all crypto functions (hkdf_extract and hkdf_expand)

### DIFF
--- a/evercrypt_cryptolib/src/lib.rs
+++ b/evercrypt_cryptolib/src/lib.rs
@@ -471,7 +471,7 @@ fn hkdf_expand_unsafe(k: &Key, info: &ByteSeq, len: usize) -> CryptoByteSeqResul
 }
 
 /// HKDF Extract.
-pub fn hkdf_extract(ha: HashAlgorithm, k: &Key, salt: &Key) -> CryptoByteSeqResult {
+pub fn hkdf_extract(ha: &HashAlgorithm, k: &Key, salt: &Key) -> CryptoByteSeqResult {
     match ha {
         HashAlgorithm::SHA256 => hkdf_extract_unsafe(k, salt),
         HashAlgorithm::SHA384 => CryptoByteSeqResult::Err(UNSUPPORTED_ALGORITHM),
@@ -480,7 +480,7 @@ pub fn hkdf_extract(ha: HashAlgorithm, k: &Key, salt: &Key) -> CryptoByteSeqResu
 }
 
 /// HKDF Expand.
-pub fn hkdf_expand(ha: HashAlgorithm, k: &Key, info: &ByteSeq, len: usize) -> CryptoByteSeqResult {
+pub fn hkdf_expand(ha: &HashAlgorithm, k: &Key, info: &ByteSeq, len: usize) -> CryptoByteSeqResult {
     match ha {
         HashAlgorithm::SHA256 => hkdf_expand_unsafe(k, info, len),
         HashAlgorithm::SHA384 => CryptoByteSeqResult::Err(UNSUPPORTED_ALGORITHM),

--- a/hacspec_cryptolib/src/lib.rs
+++ b/hacspec_cryptolib/src/lib.rs
@@ -54,7 +54,7 @@ pub fn hash(ha: &HashAlgorithm, payload: &ByteSeq) -> CryptoByteSeqResult {
 }
 
 /// HKDF Extract.
-pub fn hkdf_extract(ha: HashAlgorithm, k: &Key, salt: &Key) -> CryptoByteSeqResult {
+pub fn hkdf_extract(ha: &HashAlgorithm, k: &Key, salt: &Key) -> CryptoByteSeqResult {
     match ha {
         HashAlgorithm::SHA256 => CryptoByteSeqResult::Ok(Key::from_seq(&extract(salt, k))),
         HashAlgorithm::SHA384 => CryptoByteSeqResult::Err(UNSUPPORTED_ALGORITHM),
@@ -63,7 +63,7 @@ pub fn hkdf_extract(ha: HashAlgorithm, k: &Key, salt: &Key) -> CryptoByteSeqResu
 }
 
 /// HKDF Expand.
-pub fn hkdf_expand(ha: HashAlgorithm, k: &Key, info: &ByteSeq, len: usize) -> CryptoByteSeqResult {
+pub fn hkdf_expand(ha: &HashAlgorithm, k: &Key, info: &ByteSeq, len: usize) -> CryptoByteSeqResult {
     match ha {
         HashAlgorithm::SHA256 => match expand(k, info, len) {
             HkdfByteSeqResult::Ok(b) => CryptoByteSeqResult::Ok(b),


### PR DESCRIPTION
This PR makes the type signature of `hkdf_extract` and `hkdf_expand` consistent with other crypto functions in that they now borrow the first argument `&HashAlgorithm` instead of copying it.